### PR TITLE
search: pseudoalignment: extend regions by chaining 2-mers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ However, indexes created by this version is not compatible with previous version
       We also [recommend controlling the number of batches for better performance](https://bioinf.shenwei.me/LexicMap/tutorials/index/#notes-for-indexing-with-large-datasets).
     - **Fix seed desert filling near gap regions**.
 - `lexicmap search`:
+    - **Improve pseudoalignment to produce longer alignment regions**.
     - Reduce memory usage.
 - `lexicmap utils seed-pos`:
     - Change default option values of sliding window.

--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ Query = GCF_003697165.2_r40
 Length = 186
 
 [Subject genome #1/2] = GCF_002950215.1 Shigella flexneri
-Query coverage per genome = 88.710%
+Query coverage per genome = 93.548%
 
 >NZ_CP026788.1 
 Length = 4659463
 
  HSP #1
- Query coverage per seq = 88.710%, Aligned length = 168, Identities = 89.286%, Gaps = 5
- Query range = 13-177, Subject range = 1124816-1124981, Strand = Plus/Plus
+ Query coverage per seq = 93.548%, Aligned length = 177, Identities = 88.701%, Gaps = 6
+ Query range = 13-186, Subject range = 1124816-1124989, Strand = Plus/Plus
 
 Query  13       CGGAAACTGAAACA-CCAGATTCTACGATGATTATGATGATTTA-TGCTTTCTTTACTAA  70
                 |||||||||||||| |||||||||| | |||||||||||||||| |||||||||| ||||
@@ -155,9 +155,9 @@ Query  71       AAAGTAAGCGGCCAAAAAAATGAT-AACACCTGTAATGAGTATCAGAAAAGACACGGTAA  12
                 ||    |||||||||||||||||| |||||||||||||||||||||||||||||||||||
 Sbjct  1124876  AA--GCAGCGGCCAAAAAAATGATTAACACCTGTAATGAGTATCAGAAAAGACACGGTAA  1124933
 
-Query  130      GAAAACACTCTTTTGGATACCTAGAGTCTGATAAGCGATTATTCTCTC  177
-                 || |||||||||    |||||  ||||||||||||||||||||||||
-Sbjct  1124934  AAAGACACTCTTTGAAGTACCTGAAGTCTGATAAGCGATTATTCTCTC  1124981
+Query  130      GAAAACACTCTTTTGGATACCTAGAGTCTGATAAGCGATTATTCTCTCTATGTTACT  186
+                 || |||||||||    |||||  |||||||||||||||||||||||| |||| |||
+Sbjct  1124934  AAAGACACTCTTTGAAGTACCTGAAGTCTGATAAGCGATTATTCTCTCCATGT-ACT  1124989
 ```
 
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -412,14 +412,14 @@ Query = GCF_003697165.2_r40
 Length = 186
 
 [Subject genome #1/2] = GCF_002950215.1 Shigella flexneri
-Query coverage per genome = 88.710%
+Query coverage per genome = 93.548%
 
 >NZ_CP026788.1 
 Length = 4659463
 
  HSP #1
- Query coverage per seq = 88.710%, Aligned length = 168, Identities = 89.286%, Gaps = 5
- Query range = 13-177, Subject range = 1124816-1124981, Strand = Plus/Plus
+ Query coverage per seq = 93.548%, Aligned length = 177, Identities = 88.701%, Gaps = 6
+ Query range = 13-186, Subject range = 1124816-1124989, Strand = Plus/Plus
 
 Query  13       CGGAAACTGAAACA-CCAGATTCTACGATGATTATGATGATTTA-TGCTTTCTTTACTAA  70
                 |||||||||||||| |||||||||| | |||||||||||||||| |||||||||| ||||
@@ -429,8 +429,8 @@ Query  71       AAAGTAAGCGGCCAAAAAAATGAT-AACACCTGTAATGAGTATCAGAAAAGACACGGTAA  12
                 ||    |||||||||||||||||| |||||||||||||||||||||||||||||||||||
 Sbjct  1124876  AA--GCAGCGGCCAAAAAAATGATTAACACCTGTAATGAGTATCAGAAAAGACACGGTAA  1124933
 
-Query  130      GAAAACACTCTTTTGGATACCTAGAGTCTGATAAGCGATTATTCTCTC  177
-                 || |||||||||    |||||  ||||||||||||||||||||||||
-Sbjct  1124934  AAAGACACTCTTTGAAGTACCTGAAGTCTGATAAGCGATTATTCTCTC  1124981
+Query  130      GAAAACACTCTTTTGGATACCTAGAGTCTGATAAGCGATTATTCTCTCTATGTTACT  186
+                 || |||||||||    |||||  |||||||||||||||||||||||| |||| |||
+Sbjct  1124934  AAAGACACTCTTTGAAGTACCTGAAGTCTGATAAGCGATTATTCTCTCCATGT-ACT  1124989
 
 ```

--- a/docs/content/introduction/_index.md
+++ b/docs/content/introduction/_index.md
@@ -141,14 +141,14 @@ Query = GCF_003697165.2_r40
 Length = 186
 
 [Subject genome #1/2] = GCF_002950215.1 Shigella flexneri
-Query coverage per genome = 88.710%
+Query coverage per genome = 93.548%
 
 >NZ_CP026788.1 
 Length = 4659463
 
  HSP #1
- Query coverage per seq = 88.710%, Aligned length = 168, Identities = 89.286%, Gaps = 5
- Query range = 13-177, Subject range = 1124816-1124981, Strand = Plus/Plus
+ Query coverage per seq = 93.548%, Aligned length = 177, Identities = 88.701%, Gaps = 6
+ Query range = 13-186, Subject range = 1124816-1124989, Strand = Plus/Plus
 
 Query  13       CGGAAACTGAAACA-CCAGATTCTACGATGATTATGATGATTTA-TGCTTTCTTTACTAA  70
                 |||||||||||||| |||||||||| | |||||||||||||||| |||||||||| ||||
@@ -158,9 +158,9 @@ Query  71       AAAGTAAGCGGCCAAAAAAATGAT-AACACCTGTAATGAGTATCAGAAAAGACACGGTAA  12
                 ||    |||||||||||||||||| |||||||||||||||||||||||||||||||||||
 Sbjct  1124876  AA--GCAGCGGCCAAAAAAATGATTAACACCTGTAATGAGTATCAGAAAAGACACGGTAA  1124933
 
-Query  130      GAAAACACTCTTTTGGATACCTAGAGTCTGATAAGCGATTATTCTCTC  177
-                 || |||||||||    |||||  ||||||||||||||||||||||||
-Sbjct  1124934  AAAGACACTCTTTGAAGTACCTGAAGTCTGATAAGCGATTATTCTCTC  1124981
+Query  130      GAAAACACTCTTTTGGATACCTAGAGTCTGATAAGCGATTATTCTCTCTATGTTACT  186
+                 || |||||||||    |||||  |||||||||||||||||||||||| |||| |||
+Sbjct  1124934  AAAGACACTCTTTGAAGTACCTGAAGTCTGATAAGCGATTATTCTCTCCATGT-ACT  1124989
 
 ```
 

--- a/docs/content/tutorials/search.md
+++ b/docs/content/tutorials/search.md
@@ -246,28 +246,28 @@ Here are some tips to improve the search speed.
 
     Query = GCF_003697165.2_r40
     Length = 186
-
+    
     [Subject genome #1/2] = GCF_002950215.1 Shigella flexneri
-    Query coverage per genome = 88.710%
-
+    Query coverage per genome = 93.548%
+    
     >NZ_CP026788.1 
     Length = 4659463
-
-    HSP #1
-    Query coverage per seq = 88.710%, Aligned length = 168, Identities = 89.286%, Gaps = 5
-    Query range = 13-177, Subject range = 1124816-1124981, Strand = Plus/Plus
-
+    
+     HSP #1
+     Query coverage per seq = 93.548%, Aligned length = 177, Identities = 88.701%, Gaps = 6
+     Query range = 13-186, Subject range = 1124816-1124989, Strand = Plus/Plus
+    
     Query  13       CGGAAACTGAAACA-CCAGATTCTACGATGATTATGATGATTTA-TGCTTTCTTTACTAA  70
                     |||||||||||||| |||||||||| | |||||||||||||||| |||||||||| ||||
     Sbjct  1124816  CGGAAACTGAAACAACCAGATTCTATGTTGATTATGATGATTTAATGCTTTCTTTGCTAA  1124875
-
+    
     Query  71       AAAGTAAGCGGCCAAAAAAATGAT-AACACCTGTAATGAGTATCAGAAAAGACACGGTAA  129
                     ||    |||||||||||||||||| |||||||||||||||||||||||||||||||||||
     Sbjct  1124876  AA--GCAGCGGCCAAAAAAATGATTAACACCTGTAATGAGTATCAGAAAAGACACGGTAA  1124933
-
-    Query  130      GAAAACACTCTTTTGGATACCTAGAGTCTGATAAGCGATTATTCTCTC  177
-                    || |||||||||    |||||  ||||||||||||||||||||||||
-    Sbjct  1124934  AAAGACACTCTTTGAAGTACCTGAAGTCTGATAAGCGATTATTCTCTC  1124981
+    
+    Query  130      GAAAACACTCTTTTGGATACCTAGAGTCTGATAAGCGATTATTCTCTCTATGTTACT  186
+                     || |||||||||    |||||  |||||||||||||||||||||||| |||| |||
+    Sbjct  1124934  AAAGACACTCTTTGAAGTACCTGAAGTCTGATAAGCGATTATTCTCTCCATGT-ACT  1124989
     ```
 
 

--- a/lexicmap/cmd/lib-chaining3.go
+++ b/lexicmap/cmd/lib-chaining3.go
@@ -1,0 +1,299 @@
+// Copyright © 2023-2024 Wei Shen <shenwei356@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"sync"
+)
+
+// Chaining3Options contains all options in chaining.
+type Chaining3Options struct {
+	MaxGap      int
+	MinScore    int // minimum score of a chain
+	MinAlignLen int
+	MinIdentity float64
+	MaxDistance int
+	BandCount   int // only check i in range of  i − A < j < i
+	BandBase    int // only check i where i.Qstart+i.Len + A < j.Qstart
+}
+
+// DefaultChaining3Options is the defalt vaule of Chaining2Option.
+var DefaultChaining3Options = Chaining3Options{
+	MaxGap:      5,
+	MinScore:    1,
+	MinAlignLen: 2,
+
+	MaxDistance: 10,
+	BandCount:   20,
+	BandBase:    10,
+}
+
+// Chainer3 is an object for chaining the anchors in two similar sequences.
+// Anchors/seeds/substrings in Chainer3 is denser than those in Chainer,
+// and the chaining score function is also much simpler, only considering
+// the lengths of anchors and gaps between them.
+type Chainer3 struct {
+	options *Chaining3Options
+
+	maxscoresIdxs []int64 // pack score (32bit) and index (32bit) to save ram.
+}
+
+// NewChainer creates a new chainer.
+func NewChainer3(options *Chaining3Options) *Chainer3 {
+	c := &Chainer3{
+		options: options,
+
+		maxscoresIdxs: make([]int64, 0, 128),
+	}
+	return c
+}
+
+var poolChainers3 = &sync.Pool{New: func() interface{} {
+	return NewChainer3(&DefaultChaining3Options)
+}}
+
+var poolChain3 = &sync.Pool{New: func() interface{} {
+	return &Chain3Result{}
+}}
+
+// Chain3Result represents a result of a chain
+type Chain3Result struct {
+	NAnchors int // The number of substrings
+
+	AlignedFraction float64
+
+	MatchedBases  int     // The number of matched bases.
+	AlignedBasesQ int     // The number of aligned bases in Query sequence
+	AlignedBasesT int     // The number of aligned bases in Subject sequence
+	PIdent        float64 // percentage of identity
+	AlignedLength int     // Aligned length, might be longer than AlignedBasesQ or AlignedBasesT
+	Gaps          int     // The number of gaps
+
+	QBegin, QEnd int // Query begin/end position (0-based)
+	TBegin, TEnd int // Target begin/end position (0-based)
+}
+
+// Reset resets a Chain3Result
+func (r *Chain3Result) Reset() {
+	r.NAnchors = 0
+}
+
+var sub0 = &SubstrPair{}
+
+// Chain finds the possible chain path.
+// Please remember to call RecycleChaining3Result after using the results.
+// Returned results:
+//  1. Chain3Result.
+//  2. The number of matched bases.
+//  3. The number of aligned bases.
+//  4. QBegin.
+//  5. QEnd.
+//  6. TBegin.
+//  7. TEnd.
+func (ce *Chainer3) Chain(subs *[]*SubstrPair) *Chain3Result {
+	n := len(*subs)
+
+	var i, j int
+	bandBase := int32(ce.options.BandBase) // band size of banded-DP
+	bandCount := ce.options.BandCount
+	var _bCount int
+	var _bBase int32
+
+	maxscoresIdxs := &ce.maxscoresIdxs
+	*maxscoresIdxs = (*maxscoresIdxs)[:0]
+
+	// compute scores
+	var s, m, M, g, d float64
+	var mj, Mi int
+	var a, b *SubstrPair
+	maxGap := float64(ce.options.MaxGap)
+	maxDistance := float64(ce.options.MaxDistance)
+
+	// initialize
+	a = (*subs)[0]
+	m = float64(a.Len) - distance2(sub0, a) - gap2(sub0, a)
+	*maxscoresIdxs = append(*maxscoresIdxs, int64(m)<<32)
+
+	for i = 1; i < n; i++ {
+		a = (*subs)[i] // current seed/anchor
+
+		// just initialize the max score, which comes from the current seed
+		m, mj = float64(a.Len)-distance2(sub0, a)-gap2(sub0, a), i
+
+		j = i
+		_bCount = 0
+		// fmt.Printf("i: %d, %s\n", i, a.String())
+		for {
+			j--
+			if j < 0 {
+				break
+			}
+
+			b = (*subs)[j] // previous seed/anchor
+
+			// no need to clean as anchors have the same size 2
+			// filter out messed/crossed anchors
+			// if b.QBegin == a.QBegin || b.TBegin > a.TBegin {
+			// 	continue
+			// }
+
+			_bCount++
+
+			_bBase = a.QBegin - b.QBegin - int32(b.Len)
+			if !(_bBase <= bandBase || _bCount <= bandCount) {
+				break
+			}
+
+			d = distance2(a, b)
+			if d > maxDistance {
+				continue
+			}
+
+			g = gap2(a, b)
+			if g > maxGap {
+				continue
+			}
+
+			s = float64((*maxscoresIdxs)[j]>>32) + float64(b.Len) - d - g // compute the score
+
+			if s >= m { // update the max score of current seed/anchor
+				m = s
+				mj = j
+			}
+		}
+
+		*maxscoresIdxs = append(*maxscoresIdxs, int64(m)<<32|int64(mj))
+
+		if m > M { // the biggest score in the whole score matrix
+			M, Mi = m, i
+		}
+	}
+
+	// fmt.Printf("M: %f, Mi: %d\n", M, Mi)
+
+	// // print the score matrix
+	// fmt.Printf("i\tpair-i\tiMax\tj:scores\n")
+	// var _mi int64
+	// for i = 0; i < n; i++ {
+	// 	_mi = (*maxscoresIdxs)[i]
+	// 	fmt.Printf("%d\t%s\t%d:%d", i, (*subs)[i], _mi&4294967295, _mi>>32)
+	// 	fmt.Printf("\n")
+	// }
+
+	// backtrack -----------------------------------------------------------
+
+	minScore := float64(ce.options.MinScore)
+	minAlignLen := ce.options.MinAlignLen
+
+	// check the highest score, for early quit,
+	if M < minScore {
+		return nil
+	}
+
+	var nMatchedBases, nAlignedBasesQ, nAlignedBasesT int
+
+	i = Mi
+	var qb, qe, tb, te int32 // the bound (0-based)
+	var sub *SubstrPair
+	var beginOfNextAnchor int
+	var pident float64
+	firstAnchorOfAChain := true
+	path := poolChain3.Get().(*Chain3Result)
+	path.Reset()
+	for {
+		j = int((*maxscoresIdxs)[i] & 4294967295) // previous seed
+
+		if j < 0 { // the first anchor is not in current region
+			break
+		}
+
+		sub = (*subs)[i]
+
+		path.NAnchors++
+
+		// fmt.Printf(" AAADDD %d (%s). firstAnchorOfAChain: %v\n", i, *sub, firstAnchorOfAChain)
+
+		if firstAnchorOfAChain {
+			// fmt.Printf(" record bound beginning with: %s\n", sub)
+			firstAnchorOfAChain = false
+
+			qe = int32(sub.QBegin) + int32(sub.Len) - 1   // end
+			te = int32(sub.TBegin) + int32(sub.Len) - 1   // end
+			qb, tb = int32(sub.QBegin), int32(sub.TBegin) // in case there's only one anchor
+
+			nMatchedBases += int(sub.Len)
+		} else {
+			qb, tb = int32(sub.QBegin), int32(sub.TBegin) // begin
+
+			if int(sub.QBegin)+int(sub.Len)-1 >= beginOfNextAnchor {
+				nMatchedBases += beginOfNextAnchor - int(sub.QBegin)
+			} else {
+				nMatchedBases += int(sub.Len)
+			}
+		}
+		beginOfNextAnchor = int(sub.QBegin)
+
+		if i == j { // the path starts here
+			if firstAnchorOfAChain { // sadly, there's no anchor added.
+				break
+			}
+
+			nAlignedBasesQ += int(qe) - int(qb) + 1
+
+			if nAlignedBasesQ < minAlignLen {
+				firstAnchorOfAChain = true
+				break
+			}
+
+			nAlignedBasesT += int(te) - int(tb) + 1
+
+			pident = float64(nMatchedBases) / float64(max(nAlignedBasesQ, nAlignedBasesT)) * 100
+			// fmt.Println(nMatchedBases, nAlignedBasesQ, pident)
+
+			// the pident here (pseudo alignment) would be much lower than the real one .
+			if pident < 15 {
+				firstAnchorOfAChain = true
+				break
+			}
+			if pident > 100 {
+				pident = 100
+			}
+
+			// reverseInts(path.Chain)
+			path.AlignedBasesQ = nAlignedBasesQ
+			path.AlignedBasesT = nAlignedBasesT
+			path.MatchedBases = nMatchedBases
+			path.PIdent = pident
+			path.QBegin, path.QEnd = int(qb), int(qe)
+			path.TBegin, path.TEnd = int(tb), int(te)
+
+			// fmt.Printf("chain a %d (%d, %d) vs (%d, %d), a:%d, m:%d\n",
+			// 	len(*paths), qb, qe, tb, te, nAlignedBasesQ, nMatchedBases)
+
+			firstAnchorOfAChain = true
+			break
+		}
+
+		i = j
+	}
+
+	return path
+}

--- a/lexicmap/cmd/lib-index-search-util.go
+++ b/lexicmap/cmd/lib-index-search-util.go
@@ -1,0 +1,199 @@
+// Copyright © 2023-2024 Wei Shen <shenwei356@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/shenwei356/LexicMap/lexicmap/cmd/tree"
+	"github.com/shenwei356/lexichash/iterator"
+)
+
+// extendMatch an alignment region using a chaining algorithm
+func extendMatch(seq1, seq2 []byte, start1, end1, start2, end2 int, extLen int) ([]byte, []byte, int, int, int, int, error) {
+	var m uint8 = 2
+
+	// fmt.Println("before:", start1, end1, start2, end2)
+
+	var _s1, _e1, _s2, _e2 int // extend length
+
+	// 3', right
+	if end1+int(m) < len(seq1) && end2+int(m) < len(seq2) {
+		e1, e2 := min(end1+extLen, len(seq1)), min(end2+extLen, len(seq2))
+		_seq1, _seq2 := seq1[end1:e1], seq2[end2:e2]
+		// fmt.Printf("seq1: %s\nseq2: %s\n", _seq1, _seq2)
+
+		_e1, _e2 = _extendRight(_seq1, _seq2)
+		if _e1 > 0 || _e2 > 0 {
+			end1 += _e1
+			end2 += _e2
+		}
+	}
+
+	// 5', left
+	if start1 > int(m) && start2 > int(m) {
+		s1, s2 := max(start1-extLen, 0), max(start2-extLen, 0)
+		_seq1, _seq2 := reverseBytes(seq1[s1:start1]), reverseBytes(seq2[s2:start2])
+
+		_s1, _s2 = _extendRight(*_seq1, *_seq2)
+		if _s1 > 0 || _s2 > 0 {
+			start1 -= _s1
+			start2 -= _s2
+		}
+		poolRevBytes.Put(_seq1)
+		poolRevBytes.Put(_seq2)
+	}
+
+	// fmt.Println("after:", start1, end1, start2, end2)
+	return seq1[start1:end1], seq2[start2:end2], _s1, _e1, _s2, _e2, nil
+}
+
+func _extendRight(s1, s2 []byte) (int, int) {
+	_k := 2
+	var m uint8 = 2
+
+	// k-mer iterator
+	iter, err := iterator.NewKmerIterator(s1, _k)
+	if err != nil {
+		return 0, 0
+	}
+
+	// index
+	t := tree.NewTree(uint8(_k))
+	var kmer uint64
+	var ok bool
+	for {
+		kmer, ok, _ = iter.NextPositiveKmer()
+		if !ok {
+			break
+		}
+		t.Insert(kmer, uint32(iter.Index()))
+	}
+
+	// match
+	iter, err = iterator.NewKmerIterator(s2, _k)
+	if err != nil {
+		return 0, 0
+	}
+
+	subs := poolSubs.Get().(*[]*SubstrPair)
+	*subs = (*subs)[:0]
+
+	var v, p uint32
+	var srs *[]*tree.SearchResult
+	var sr *tree.SearchResult
+
+	for {
+		kmer, ok, _ = iter.NextPositiveKmer()
+		if !ok {
+			break
+		}
+
+		srs, ok = t.Search(kmer, m)
+		if !ok {
+			continue
+		}
+
+		for _, sr = range *srs {
+			// fmt.Printf("%s vs %s, len:%d\n", kmers.MustDecode(kmer, _k), kmers.MustDecode(sr.Kmer, _k), sr.LenPrefix)
+			for _, v = range sr.Values {
+				p = v
+
+				_sub := poolSub.Get().(*SubstrPair)
+				_sub.QBegin = int32(p)
+				_sub.TBegin = int32(iter.Index())
+				_sub.Len = uint8(sr.LenPrefix)
+				_sub.QRC = false
+				_sub.TRC = false
+
+				*subs = append(*subs, _sub)
+			}
+		}
+		t.RecycleSearchResult(srs)
+	}
+	tree.RecycleTree(t)
+
+	if len(*subs) == 0 {
+		return 0, 0
+	}
+
+	if len(*subs) > 1 {
+		// no need to clean as k == min_len
+		// ClearSubstrPairs(poolSub, subs, _k)
+
+		slices.SortFunc(*subs, func(a, b *SubstrPair) int {
+			if a.QBegin == b.QBegin {
+				if a.QBegin+int32(a.Len) == b.QBegin+int32(b.Len) {
+					return int(a.TBegin - b.TBegin)
+				}
+				return int(b.QBegin) + int(b.Len) - (int(a.QBegin) + int(a.Len))
+			}
+			return int(a.QBegin - b.QBegin)
+		})
+	}
+
+	// for _, s := range *subs {
+	// 	fmt.Println(s)
+	// }
+
+	// chaining
+	chainer := poolChainers3.Get().(*Chainer3)
+	chain := chainer.Chain(subs)
+
+	RecycleSubstrPairs(poolSub, subs)
+	poolChainers3.Put(chainer)
+
+	if chain != nil {
+		// fmt.Printf("q: %d-%d, t: %d-%d\n", chain.QBegin, chain.QEnd, chain.TBegin, chain.TEnd)
+		poolChain3.Put(chain)
+		return chain.QEnd + 1, chain.TEnd + 1
+	}
+
+	return 0, 0
+}
+
+// remember to recycle the result
+func reverseBytes(s []byte) *[]byte {
+	t := poolRevBytes.Get().(*[]byte)
+	if len(s) == len(*t) {
+
+	} else if len(s) < len(*t) {
+		*t = (*t)[:len(s)]
+	} else {
+		n := len(s) - len(*t)
+		for i := 0; i < n; i++ {
+			*t = append(*t, 0)
+		}
+	}
+	copy(*t, s)
+
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		(*t)[i], (*t)[j] = (*t)[j], (*t)[i]
+	}
+
+	return t
+}
+
+var poolRevBytes = &sync.Pool{New: func() interface{} {
+	tmp := make([]byte, 128)
+	return &tmp
+}}

--- a/lexicmap/cmd/lib-seq_compare.go
+++ b/lexicmap/cmd/lib-seq_compare.go
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Wei Shen <sheTopLeftei356@gmail.com>
+// Copyright © 2023-2024 Wei Shen <shenwei356@gmail.com>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/lexicmap/cmd/lib-seq_compare_test.go
+++ b/lexicmap/cmd/lib-seq_compare_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Wei Shen <sheTopLeftei356@gmail.com>
+// Copyright © 2023-2024 Wei Shen <shenwei356@gmail.com>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/lexicmap/cmd/search.go
+++ b/lexicmap/cmd/search.go
@@ -267,7 +267,8 @@ Result ordering:
 			MaxGap:      float64(maxGap),
 			MaxDistance: float64(maxDist),
 
-			ExtendLength: extLen,
+			ExtendLength:  extLen,
+			ExtendLength2: 50,
 
 			MinQueryAlignedFractionInAGenome: minQcovGenome,
 


### PR DESCRIPTION
It should slightly improve the alignment metrics.

Previous:

```
 Query coverage per seq = 88.710%, Aligned length = 168, Identities = 89.286%, Gaps = 5
 Query range = 13-177, Subject range = 1124816-1124981, Strand = Plus/Plus

Query  13       CGGAAACTGAAACA-CCAGATTCTACGATGATTATGATGATTTA-TGCTTTCTTTACTAA  70
                |||||||||||||| |||||||||| | |||||||||||||||| |||||||||| ||||
Sbjct  1124816  CGGAAACTGAAACAACCAGATTCTATGTTGATTATGATGATTTAATGCTTTCTTTGCTAA  1124875

Query  71       AAAGTAAGCGGCCAAAAAAATGAT-AACACCTGTAATGAGTATCAGAAAAGACACGGTAA  129
                ||    |||||||||||||||||| |||||||||||||||||||||||||||||||||||
Sbjct  1124876  AA--GCAGCGGCCAAAAAAATGATTAACACCTGTAATGAGTATCAGAAAAGACACGGTAA  1124933

Query  130      GAAAACACTCTTTTGGATACCTAGAGTCTGATAAGCGATTATTCTCTC  177
                 || |||||||||    |||||  ||||||||||||||||||||||||
Sbjct  1124934  AAAGACACTCTTTGAAGTACCTGAAGTCTGATAAGCGATTATTCTCTC  1124981
```
Now (in this example, only the downstream region is extended), it's the same as Blastn's result.
```
 Query coverage per seq = 93.548%, Aligned length = 177, Identities = 88.701%, Gaps = 6
 Query range = 13-186, Subject range = 1124816-1124989, Strand = Plus/Plus
Query  13       CGGAAACTGAAACA-CCAGATTCTACGATGATTATGATGATTTA-TGCTTTCTTTACTAA  70
                |||||||||||||| |||||||||| | |||||||||||||||| |||||||||| ||||
Sbjct  1124816  CGGAAACTGAAACAACCAGATTCTATGTTGATTATGATGATTTAATGCTTTCTTTGCTAA  1124875

Query  71       AAAGTAAGCGGCCAAAAAAATGAT-AACACCTGTAATGAGTATCAGAAAAGACACGGTAA  129
                ||    |||||||||||||||||| |||||||||||||||||||||||||||||||||||
Sbjct  1124876  AA--GCAGCGGCCAAAAAAATGATTAACACCTGTAATGAGTATCAGAAAAGACACGGTAA  1124933
                  ==== 
                  ^ Here it's different from blastn, but it doesn't matter.

Query  130      GAAAACACTCTTTTGGATACCTAGAGTCTGATAAGCGATTATTCTCTCTATGTTACT  186
                 || |||||||||    |||||  |||||||||||||||||||||||| |||| |||          <==== see here
Sbjct  1124934  AAAGACACTCTTTGAAGTACCTGAAGTCTGATAAGCGATTATTCTCTCCATGT-ACT  1124989
```

Blastn
```
 Identities = 160/178 (90%), Gaps = 8/178 (4%)
 Strand=Plus/Plus

Query  13       CGGAAACTGAAAC-ACCAGATTCTACGATGATTATGATGATTT-ATGCTTTCTTTACTAA  70
                ||||||||||||| ||||||||||| | ||||||||||||||| ||||||||||| ||||
Sbjct  1124816  CGGAAACTGAAACAACCAGATTCTATGTTGATTATGATGATTTAATGCTTTCTTTGCTAA  1124875

Query  71       AAAGTAAGCGGCCaaaaaaaTGA-TAACACCTGTAATGAGTATCAGAAAAGACACGGTAA  129
                || |  ||||||||||||||||| ||||||||||||||||||||||||||||||||||||
Sbjct  1124876  AA-G-CAGCGGCCAAAAAAATGATTAACACCTGTAATGAGTATCAGAAAAGACACGGTAA  1124933

Query  130      GAAAACACTCTTTTGGA-TACCTAGAGTCTGATAAGCGATTATTCTCTCTATGTTACT  186
                 || ||||||||| | | |||||  |||||||||||||||||||||||| |||| |||
Sbjct  1124934  AAAGACACTCTTT-GAAGTACCTGAAGTCTGATAAGCGATTATTCTCTCCATGT-ACT  1124989
```